### PR TITLE
MPRSS 987 Panel de terceros: Visualizar información sobre la fecha del pedido

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "crypto-js": "^4.1.1",
         "file-saver": "^2.0.5",
         "leaflet": "^1.9.4",
+        "moment": "^2.29.4",
         "ng-zorro-antd": "^17.0.1",
         "rxjs": "~7.8.1",
         "xlsx": "^0.18.5",
@@ -8872,6 +8873,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "crypto-js": "^4.1.1",
     "file-saver": "^2.0.5",
     "leaflet": "^1.9.4",
+    "moment": "^2.29.4",
     "ng-zorro-antd": "^17.0.1",
     "rxjs": "~7.8.1",
     "xlsx": "^0.18.5",

--- a/src/app/core/baseForm/base-form-order.service.ts
+++ b/src/app/core/baseForm/base-form-order.service.ts
@@ -26,7 +26,14 @@ export class BaseFormOrderService {
 
     setValidators(order: any, form: FormGroup) {
         Object.keys(order).forEach(key => {
-            if (key != 'instructions' && key != 'orderId' && key != 'dni' && key != 'addressDetail' && key != 'indications' && key != 'createDate' && key != 'state' && key != 'cityId') {
+            if (key != 'instructions' &&
+                key != 'orderId' &&
+                key != 'dni' &&
+                key != 'addressDetail' &&
+                key != 'indications' &&
+                key != 'createDate' &&
+                key != 'state' &&
+                key != 'cityId') {
                 form.get(key)?.setValidators(Validators.required);
             }
             if (key == 'email') {

--- a/src/app/core/models/order.class.ts
+++ b/src/app/core/models/order.class.ts
@@ -23,6 +23,7 @@ export class Order {
     state: string;
     storeId: number;
     cityId : string;
+    createDate : string;
     constructor() {
         this.orderId = 0;
         this.business_id = Storage.getAll(BUSINESS_DATA).id;
@@ -64,5 +65,6 @@ export class Order {
         this.token = 0;
         this.storeId = 0;
         this.cityId = '';
+        this.createDate = '';
     }
 }

--- a/src/app/core/view-model/orders.vm.ts
+++ b/src/app/core/view-model/orders.vm.ts
@@ -7,6 +7,7 @@ import { Order } from "../models/order.class";
 import { countryConfig } from 'src/country-config/country-config';
 import { COUNTRIES_COL } from "src/app/cities-col-temporal";
 import { COUNTRIES_VZLA } from "src/app/cities-ven-temporal";
+import * as moment from "moment";
 
 @Injectable({
     providedIn: 'root'
@@ -87,20 +88,30 @@ export class OrdersVm {
     }
 
     filterData(changes): void {
-        console.log(changes)
-        let { branchOffice, city } = changes;
+        let { branchOffice, city, date } = changes;
         if (city) {
             const cityId = this.cityMap[city];
             if (branchOffice) {
-                let filteredData = this.cacheList.filter(item => item.storeId === branchOffice && item.cityId === cityId);
-                this.updateDataList(filteredData)
+                if (date.length > 0) {
+                    this.filterByBranchOfficeCityAndDate(branchOffice, cityId, date)
+                } else {
+                    this.filterByBranchOfficeAndCity(branchOffice, cityId);
+                }
             } else {
-                let filteredData = this.cacheList.filter(item => item.cityId === cityId);
-                this.updateDataList(filteredData)
+                if (date?.length > 0) {
+                    this.filterByCityAndDate(cityId, date)
+                } else {
+                    this.filterByCity(cityId)
+                }
             }
         } else if (branchOffice) {
-            let filteredData = this.cacheList.filter(item => item.storeId === branchOffice);
-            this.updateDataList(filteredData)
+            if (date?.length > 0) {
+                this.filterByBranchOfficeAndDate(branchOffice, date)
+            } else {
+                this.filterByBranchOffice(branchOffice);
+            }
+        } else if (date?.length > 0) {
+            this.filterByDate(date)
         } else {
             this.updateDataList(this.cacheList)
         }
@@ -108,6 +119,64 @@ export class OrdersVm {
 
     updateDataList(list): void {
         this.dataList.next(list);
+    }
+
+    filterByBranchOfficeCityAndDate(branchOffice: number, cityId: string, date): void {
+        const startDate = moment(date[0]).format('YYYY-MM-DD');
+        const endDate = moment(date[1]).format('YYYY-MM-DD');
+        let filteredData = this.cacheList.filter(item =>
+            item.storeId === branchOffice &&
+            item.cityId === cityId &&
+            (moment(item.createDate).format('YYYY-MM-DD') >= startDate &&
+                moment(item.createDate).format('YYYY-MM-DD') <= endDate)
+        );
+        this.updateDataList(filteredData);
+    }
+
+    filterByBranchOfficeAndDate(branchOffice: number, date): void {
+        const startDate = moment(date[0]).format('YYYY-MM-DD');
+        const endDate = moment(date[1]).format('YYYY-MM-DD');
+        let filteredData = this.cacheList.filter(item =>
+            item.storeId === branchOffice &&
+            (moment(item.createDate).format('YYYY-MM-DD') >= startDate &&
+                moment(item.createDate).format('YYYY-MM-DD') <= endDate)
+        );
+        this.updateDataList(filteredData);
+    }
+
+    filterByCityAndDate(cityId: string, date): void {
+        const startDate = moment(date[0]).format('YYYY-MM-DD');
+        const endDate = moment(date[1]).format('YYYY-MM-DD');
+        let filteredData = this.cacheList.filter(item =>
+            item.cityId === cityId &&
+            (moment(item.createDate).format('YYYY-MM-DD') >= startDate &&
+                moment(item.createDate).format('YYYY-MM-DD') <= endDate)
+        );
+        this.updateDataList(filteredData);
+    }
+
+    filterByDate(date): void {
+        const startDate = moment(date[0]).format('YYYY-MM-DD');
+        const endDate = moment(date[1]).format('YYYY-MM-DD');
+        let filteredData = this.cacheList.filter(item =>
+        (moment(item.createDate).format('YYYY-MM-DD') >= startDate &&
+            moment(item.createDate).format('YYYY-MM-DD') <= endDate));
+        this.updateDataList(filteredData);
+    }
+
+    filterByBranchOfficeAndCity(branchOffice: number, cityId: string): void {
+        let filteredData = this.cacheList.filter(item => item.storeId === branchOffice && item.cityId === cityId);
+        this.updateDataList(filteredData);
+    }
+
+    filterByCity(cityId: string): void {
+        let filteredData = this.cacheList.filter(item => item.cityId === cityId);
+        this.updateDataList(filteredData);
+    }
+
+    filterByBranchOffice(branchOffice: number): void {
+        let filteredData = this.cacheList.filter(item => item.storeId === branchOffice);
+        this.updateDataList(filteredData);
     }
 
 }

--- a/src/app/layouts/dashboard-layout/dashboard-layout.component.html
+++ b/src/app/layouts/dashboard-layout/dashboard-layout.component.html
@@ -39,7 +39,7 @@
     </div>
   </nz-header>
   <nz-layout class="layout-content">
-    <nz-sider *ngIf="showDrawerRef" class="menu-sidebar" nzCollapsible nzWidth="250px" nzBreakpoint="md"
+    <nz-sider *ngIf="showDrawerRef" class="menu-sidebar" nzCollapsible nzWidth="250px" nzBreakpoint="xl"
       [(nzCollapsed)]="isCollapsed" [nzTrigger]="null">
       <div class="menu-sidebar__logo-container" [ngStyle]="{'display': ( isCollapsed ? 'none' : 'flex')}">
         <div class="menu-sidebar__logo-container__logo">

--- a/src/app/pages/orders/orders.component.html
+++ b/src/app/pages/orders/orders.component.html
@@ -27,6 +27,7 @@
                 </nz-form-item>
                 <app-cities-select [isFilter]="true" [parentForm]="filterForm"
                     [customClasses]="'cities-container--filter'"></app-cities-select>
+                <nz-range-picker formControlName="date"></nz-range-picker>
             </form>
             <app-table [objectKeys]="orderModelList" [isShowItem]="true" [isCancelable]="true"
                 [listOfColumn]="listOfColumn" [listOfData]="listOfData$ | async"

--- a/src/app/pages/orders/orders.component.scss
+++ b/src/app/pages/orders/orders.component.scss
@@ -15,3 +15,7 @@
         }
     }
 }
+
+nz-range-picker{
+    height: 5rem;
+}

--- a/src/app/pages/orders/orders.component.ts
+++ b/src/app/pages/orders/orders.component.ts
@@ -52,7 +52,8 @@ export class OrdersComponent implements OnInit {
     this.filterForm = this.fb.group({
       branchOffice: '',
       state: '',
-      city: ''
+      city: '',
+      date: null
     })
   }
 

--- a/src/app/pages/orders/orders.module.ts
+++ b/src/app/pages/orders/orders.module.ts
@@ -25,6 +25,7 @@ import { OrderMessengerComponent } from './order-messenger/order-messenger.compo
 import { LoadingModule } from 'src/app/shared/components/loading/loading.module';
 import { NzAutocompleteModule } from 'ng-zorro-antd/auto-complete';
 import { ConfirmAddressPopupComponent } from 'src/app/shared/components/confirm-address-popup/confirm-address-popup.component';
+import { NzDatePickerModule } from 'ng-zorro-antd/date-picker';
 
 const antdModule = [
   NzFormModule,
@@ -34,6 +35,7 @@ const antdModule = [
   NzStepsModule,
   NzRadioModule,
   NzAutocompleteModule,
+  NzDatePickerModule,
   ConfirmAddressPopupComponent
 ]
 


### PR DESCRIPTION
Se agregó un filtro que permita listar las órdenes en función de una fecha inicial y una fecha final.
Este filtro está relacionado con los otros filtros implementados anteriormente (filtro por sucursal y ciudad).
En este momento no se completó la tarea al 100%, ya que para poder mostrar la fecha de una orden en la tabla o en su detalle, es necesaria una mejora de backend que aún no ha sido implementada.