### PR TITLE
MPRSS-1011 - En el panel de terceros: Al colocar PIN de dirección que se mantenga exactamente donde se coloca y no se centralice

### DIFF
--- a/src/app/shared/components/map/map.component.ts
+++ b/src/app/shared/components/map/map.component.ts
@@ -69,22 +69,23 @@ export class MapComponent implements OnInit, OnDestroy {
   }
 
   resolveCoordinatesToAddress({ lat, lng }) {
-    let urlInver = 'https://nominatim.openstreetmap.org/reverse?format=jsonv2&addressdetails=0&zoom=40';
-    urlInver += `&lat=${lat}&lon=${lng}`;
-    fromFetch(urlInver)
-      .pipe(switchMap((r: any) => from(r.json())))
-      .subscribe((json) => {
-        console.log(json)
-        let coordinates = {
-          lat: Number(JSON.parse(JSON.stringify(json)).lat),
-          lng: Number(JSON.parse(JSON.stringify(json)).lon)
-        }
-        // this.getAddress(coordinates)
-        let latLng = { ...coordinates }
-        this.sendLatLng.emit(coordinates);
-      }, (error) => {
-        console.log(error);
-      });
+    this.sendLatLng.emit({ lat, lng });
+    // let urlInver = 'https://nominatim.openstreetmap.org/reverse?format=jsonv2&addressdetails=0&zoom=40';
+    // urlInver += `&lat=${lat}&lon=${lng}`;
+    // fromFetch(urlInver)
+    //   .pipe(switchMap((r: any) => from(r.json())))
+    //   .subscribe((json) => {
+    //     console.log(json)
+    //     let coordinates = {
+    //       lat: Number(JSON.parse(JSON.stringify(json)).lat),
+    //       lng: Number(JSON.parse(JSON.stringify(json)).lon)
+    //     }
+    //     // this.getAddress(coordinates)
+    //     let latLng = { ...coordinates }
+    //     this.sendLatLng.emit(coordinates);
+    //   }, (error) => {
+    //     console.log(error);
+    //   });
   }
 
   getAddress(coordinates) {


### PR DESCRIPTION
Se comentó un código que en este momento no es necesario , este código hacia que ciertas latitudes y longitudes se centralizaran en una sola dirección , haciendo que se tomara una sola latitud  y longitud en función de una dirección seleccionada y no en función de donde se puso el ping.